### PR TITLE
Add validators.has_only_one_of

### DIFF
--- a/input_algorithms/validators.py
+++ b/input_algorithms/validators.py
@@ -78,12 +78,14 @@ class has_only_one_of(Validator):
     I.e. A valid dictionary must have exactly one of the specified keys!
     """
     def setup(self, choices):
+        if len(choices) < 1:
+            raise BadSpecDefinition("Must specify atleast one choice", got=choices)
         self.choices = choices
 
     def validate(self, meta, val):
         """Complain if we don't have one of the choices"""
         if [val.get(key, NotSpecified) is NotSpecified for key in self.choices].count(True) != 1:
-            raise BadSpecValue("Need to specify atleast one of the required keys", choices=self.choices, meta=meta)
+            raise BadSpecValue("Can only specify exactly one of the available choices", choices=self.choices, meta=meta)
         return val
 
 @register

--- a/input_algorithms/validators.py
+++ b/input_algorithms/validators.py
@@ -65,6 +65,28 @@ class has_either(Validator):
         return val
 
 @register
+class has_only_one_of(Validator):
+    """
+    Usage
+        .. code-block:: python
+
+            has_only_one_of([key1, ..., keyn]).normalise(meta, val)
+
+    Will complain if the ``val.get(key, NotSpecified)`` returns ``NotSpecified``
+    for all but one of the choices.
+
+    I.e. A valid dictionary must have exactly one of the specified keys!
+    """
+    def setup(self, choices):
+        self.choices = choices
+
+    def validate(self, meta, val):
+        """Complain if we don't have one of the choices"""
+        if [val.get(key, NotSpecified) is NotSpecified for key in self.choices].count(True) != 1:
+            raise BadSpecValue("Need to specify atleast one of the required keys", choices=self.choices, meta=meta)
+        return val
+
+@register
 class either_keys(Validator):
     """
     Usage

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -56,9 +56,14 @@ describe TestCase, "has_only_one_of":
         self.meta = mock.Mock(name="meta")
 
     it "takes in choices":
-        choices = mock.Mock(name="choices")
+        choices = ["one", "two"]
         validator = va.has_only_one_of(choices)
         self.assertIs(validator.choices, choices)
+
+    it "ensures choices is specified":
+        choices = []
+        with self.fuzzyAssertRaisesError(BadSpecDefinition, "Must specify atleast one choice", got=choices):
+            validator = va.has_only_one_of(choices)
 
     it "complains if none of the values are satisfied":
         choices = ["one", "two"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -51,6 +51,33 @@ describe TestCase, "has_either":
         val = {"one": 1}
         self.assertEqual(va.has_either(["one", "two"]).normalise(self.meta, val), val)
 
+describe TestCase, "has_only_one_of":
+    before_each:
+        self.meta = mock.Mock(name="meta")
+
+    it "takes in choices":
+        choices = mock.Mock(name="choices")
+        validator = va.has_only_one_of(choices)
+        self.assertIs(validator.choices, choices)
+
+    it "complains if none of the values are satisfied":
+        choices = ["one", "two"]
+        with self.fuzzyAssertRaisesError(BadSpecValue, "Can only specify exactly one of the available choices", meta=self.meta, choices=choices):
+            va.has_only_one_of(choices).normalise(self.meta, {})
+
+        with self.fuzzyAssertRaisesError(BadSpecValue, "Can only specify exactly one of the available choices", meta=self.meta, choices=choices):
+            va.has_only_one_of(choices).normalise(self.meta, {"one": NotSpecified})
+
+    it "Lets the val through if it has atleast one choice":
+        val = {"one": 1}
+        self.assertEqual(va.has_only_one_of(["one", "two"]).normalise(self.meta, val), val)
+
+    it "complains if more than one of the values are specified":
+        val = {"one": 1, "two": 2}
+        choices = ["one", "two"]
+        with self.fuzzyAssertRaisesError(BadSpecValue, "Can only specify exactly one of the available choices", meta=self.meta, choices=choices):
+            self.assertEqual(va.has_only_one_of(choices).normalise(self.meta, val), val)
+
 describe TestCase, "either_keys":
     before_each:
         self.meta = mock.Mock(name="meta")


### PR DESCRIPTION
Dictionary that must only specify one of the required keys in the set.

Couldn't think of a better name. Was previous has_one_of, but that could be read as same functionality of has_either